### PR TITLE
Gallery automation updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,3 @@
----
-topic: sample
-products:
-- office-365
-languages:
-- javascript
-extensions:
-  contentType: tools
-  createdDate: 6/5/2018 11:04:30 AM
----
 # Rialto: Make Conferences More Fun with Microsoft Teams
 Rialto improves the experience of using Microsoft Teams for conferences by showing a curated view of real-time channel chat activity that is optimized for viewing on a large screen.
 

--- a/rialto.yml
+++ b/rialto.yml
@@ -7,4 +7,4 @@ extensions:
   contentType: tools
   createdDate: '6/5/2018 11:04:30 AM'
 title: Rialto
-description: Make conferences more fun with Microsoft Teams
+description: Rialto is a Node.js application that implements a Microsoft Teams bot to listen to chat activity, and hosts a website to show the live view (along with some related stuff, like the conference agenda)

--- a/rialto.yml
+++ b/rialto.yml
@@ -1,0 +1,10 @@
+page_type: sample
+products:
+  - office-365
+languages:
+  - javascript
+extensions:
+  contentType: tools
+  createdDate: '6/5/2018 11:04:30 AM'
+title: Rialto
+description: Make conferences more fun with Microsoft Teams


### PR DESCRIPTION
I made the following changes:
- Removed YAML metadata from readme
- Added a YAML file with the metadata info

These changes allow us to automatically update the Office gallery (https://developer.microsoft.com/en-us/office/gallery) with information for this tool. This means whenever this tool is referenced in the Office / Teams Developer Portals, the user will be seeing the most up-to-date information.
